### PR TITLE
Change the animation in and out to match Google bottom sheet animations.

### DIFF
--- a/library/src/main/res/anim/dock_bottom_enter.xml
+++ b/library/src/main/res/anim/dock_bottom_enter.xml
@@ -18,7 +18,13 @@
 
 <!-- Animation for when a dock window at the bottom of the screen is entering. -->
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-        android:interpolator="@android:anim/decelerate_interpolator">
-    <translate android:fromYDelta="100%" android:toYDelta="0"
-        android:duration="250"/>
+     android:interpolator="@android:anim/decelerate_interpolator">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="15%"
+        android:toYDelta="0"/>
+    <alpha
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromAlpha="0"
+        android:toAlpha="1"/>
 </set>

--- a/library/src/main/res/anim/dock_bottom_exit.xml
+++ b/library/src/main/res/anim/dock_bottom_exit.xml
@@ -18,7 +18,13 @@
 
 <!-- Animation for when a dock window at the bottom of the screen is exiting. -->
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-        android:interpolator="@android:anim/accelerate_interpolator">
-    <translate android:fromYDelta="0" android:toYDelta="100%"
-        android:startOffset="100" android:duration="250"/>
+     android:interpolator="@android:anim/accelerate_interpolator">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="0"
+        android:toYDelta="15%"/>
+    <alpha
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromAlpha="1"
+        android:toAlpha="0"/>
 </set>


### PR DESCRIPTION
Instead of sliding all the way up from the bottom, fade in while sliding up just enough to give the hint of motion.

Demoed in person for Adit who approved.

Fixes ACA-239